### PR TITLE
build: produce releases when non-dev dependencies are updated

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -1,7 +1,12 @@
 module.exports = {
   preset: 'conventionalcommits',
   plugins: [
-    '@semantic-release/commit-analyzer',
+    [
+      '@semantic-release/commit-analyzer',
+      {
+        releaseRules: [{ type: 'build', scope: 'deps', release: 'minor' }],
+      },
+    ],
     '@semantic-release/release-notes-generator',
     '@semantic-release/changelog',
     '@semantic-release/npm',


### PR DESCRIPTION
(Port of https://github.com/GoProperly/eslint-config-properly-base/pull/38)

Configures @semantic-release/commit-analyzer to produce releases when non-dep dependencies are updated. Since this package exports a configuration that directly includes its direct dependencies, changes to those dependencies are meaningful and should result in a release.

I chose to produce a minor release for these updates, which is somewhat arbitrary (the dependency updates can themselves be major/minor/patch updates), but feels like it should be semantically correct most of the time (potentially introducing new 'features', but non-breaking).

Dev dependencies are only used for build/dev, so they are excluded from this rule.