### PR TITLE
Revert "build: produce releases when non-dev dependencies are updated"

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -1,12 +1,7 @@
 module.exports = {
   preset: 'conventionalcommits',
   plugins: [
-    [
-      '@semantic-release/commit-analyzer',
-      {
-        releaseRules: [{ type: 'build', scope: 'deps', release: 'minor' }],
-      },
-    ],
+    '@semantic-release/commit-analyzer',
     '@semantic-release/release-notes-generator',
     '@semantic-release/changelog',
     '@semantic-release/npm',


### PR DESCRIPTION
Reverts GoProperly/eslint-config-properly-react#37

See https://github.com/GoProperly/eslint-config-properly-base/pull/39 for rationale.