### PR TITLE
chore: update Dependabot token secret

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,11 +3,11 @@ registries:
   npm-registry-npm-pkg-github-com-goproperly:
     type: npm-registry
     url: https://npm.pkg.github.com/goproperly
-    token: "${{secrets.NPM_REGISTRY_NPM_PKG_GITHUB_COM_GOPROPERLY_TOKEN}}"
+    token: "${{secrets.PROPERLY_GITHUB_REPO_ACCESS}}"
   npm-registry-npm-pkg-github-com:
     type: npm-registry
     url: https://npm.pkg.github.com
-    token: "${{secrets.NPM_REGISTRY_NPM_PKG_GITHUB_COM_TOKEN}}"
+    token: "${{secrets.PROPERLY_GITHUB_REPO_ACCESS}}"
 
 updates:
 - package-ecosystem: npm


### PR DESCRIPTION
We switched to the use Dependabot using their "create a migration PR"
script. This script assumes that you'll setup some Dependabot secrets
with specific names. We have set these secrets up with different name.

Warning message:
https://github.com/GoProperly/eslint-config-properly-react/network/updates/168366061