### PR TITLE
build: use node 16 in GitHub actions, matching .nvmrc

### DIFF
--- a/.github/workflows/test_and_release.yml
+++ b/.github/workflows/test_and_release.yml
@@ -16,7 +16,7 @@ jobs:
             ${{ runner.os }}-node-
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 16
           registry-url: https://npm.pkg.github.com/
           scope: '@goproperly'
       - name: Install


### PR DESCRIPTION
We were using Node 12 in configuration for some reason, updated to .nvmrc's version
