### PR TITLE
fix: isolate testing-library/react linting rules to test files only

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,4 +20,11 @@ module.exports = {
       },
     ],
   },
+  overrides: [
+    {
+      // Enable testing-library/react but only for test files
+      files: ['**/*.test.[jt]s?(x)'],
+      extends: ['plugin:testing-library/react'],
+    },
+  ],
 };


### PR DESCRIPTION
Default setup in newer testing library plugin versions applies to all files, not just test files. This isolates the rules to test files.

Taken from https://github.com/testing-library/eslint-plugin-testing-library#run-the-plugin-only-against-test-files
