### PR TITLE
fix: tweak function-component-definition and jsx-no-useless-fragment rules to suit our codebases

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,16 @@ module.exports = {
         assertFunctionNames: ['expect', 'expectSaga'],
       },
     ],
+    // Prefer arrow function definition style over others
+    'react/function-component-definition': [
+      'error',
+      {
+        namedComponents: 'arrow-function',
+        unnamedComponents: 'arrow-function',
+      },
+    ],
+    // Allow fragments if they have strings in them, e.g. <>{title</>. Valuable for TypeScript.
+    'react/jsx-no-useless-fragment': ['error', { allowExpressions: true }],
   },
   overrides: [
     {


### PR DESCRIPTION
We prefer arrow style function definitions, e.g. `const foo = () => {}`, and we need to allow empty fragments  if they only contain a string, e.g. `<>{title}</>`. This is important for TypeScript, since it will otherwise complain about ReactElement or string not being compatible.

Rule docs:
* https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/function-component-definition.md
* https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-useless-fragment.md
