### PR TITLE
fix: update base package, allowing generators to be unnamed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.11.0",
       "license": "MIT",
       "dependencies": {
-        "@goproperly/eslint-config-properly-base": "^1.6.0",
+        "@goproperly/eslint-config-properly-base": "^1.6.1",
         "eslint-config-airbnb": "^19.0.4",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-import": "^2.26.0",
@@ -1054,9 +1054,9 @@
       }
     },
     "node_modules/@goproperly/eslint-config-properly-base": {
-      "version": "1.6.0",
-      "resolved": "https://npm.pkg.github.com/download/@GoProperly/eslint-config-properly-base/1.6.0/f4d890bfb28bb36fc9d5132f92b8b2cd9b05f3e8",
-      "integrity": "sha512-dD+B9rjwnQ2QnHT48tWcgWootnjWxYxRAjdHUXGj/rQfQfctka6/nZIcs89j25k526Ox+qSnDuC3Qx/MygkgAA==",
+      "version": "1.6.1",
+      "resolved": "https://npm.pkg.github.com/download/@GoProperly/eslint-config-properly-base/1.6.1/fd42437197fd929b5d4e31182e451ea9e06f31fa",
+      "integrity": "sha512-3sQ9qWdUfJwFwrGxzU8PePbbFu7Ns0vFzPYq0qont0EskRYb/JdoNVXYHjzk5sKeqQEM+mG2AOeuR6rL4zB66w==",
       "license": "MIT",
       "dependencies": {
         "babel-eslint": "^10.1.0",
@@ -12262,9 +12262,9 @@
       }
     },
     "@goproperly/eslint-config-properly-base": {
-      "version": "1.6.0",
-      "resolved": "https://npm.pkg.github.com/download/@GoProperly/eslint-config-properly-base/1.6.0/f4d890bfb28bb36fc9d5132f92b8b2cd9b05f3e8",
-      "integrity": "sha512-dD+B9rjwnQ2QnHT48tWcgWootnjWxYxRAjdHUXGj/rQfQfctka6/nZIcs89j25k526Ox+qSnDuC3Qx/MygkgAA==",
+      "version": "1.6.1",
+      "resolved": "https://npm.pkg.github.com/download/@GoProperly/eslint-config-properly-base/1.6.1/fd42437197fd929b5d4e31182e451ea9e06f31fa",
+      "integrity": "sha512-3sQ9qWdUfJwFwrGxzU8PePbbFu7Ns0vFzPYq0qont0EskRYb/JdoNVXYHjzk5sKeqQEM+mG2AOeuR6rL4zB66w==",
       "requires": {
         "babel-eslint": "^10.1.0",
         "eslint-config-airbnb-base": "^14.2.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     }
   },
   "dependencies": {
-    "@goproperly/eslint-config-properly-base": "^1.6.0",
+    "@goproperly/eslint-config-properly-base": "^1.6.1",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import": "^2.26.0",


### PR DESCRIPTION
Pulls in https://github.com/GoProperly/eslint-config-properly-base/pull/169
