### PR TITLE
fix: base config was being overwritten by prettier

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,8 @@ module.exports = {
   extends: [
     'airbnb',
     'airbnb/hooks',
-    '@goproperly/eslint-config-properly-base',
     'prettier',
+    '@goproperly/eslint-config-properly-base',
   ],
   env: {
     browser: true,


### PR DESCRIPTION
In frontend-common, we use the eslint-config-react package. In the base package we define a rule that "curly" should error for everything, but it wasn't being triggered with `if (foo) return`. Changing this order of extends definitions fixes that.